### PR TITLE
2022/01/21 Gamma Install Guide Changes, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # stalker-gamma-linux-guide
-<h3>Unofficially forked from [this git](https://github.com/DravenusRex/stalker-gamma-linux-guide) by [DravenusRex](https://github.com/DravenusRex/) in case of prolonged inactivity.</h3>
-<h4>Updated by me. If you would like to propose a change but you're too lazy to use github, send me an email (Discord dms suck for this) at trash-hell@sren.solutions</h4>
 
 <h3>A guide to getting S.T.A.L.K.E.R. - G.A.M.M.A. running on GNU/Linux.</h3>  
 <h4>(Henceforth referred to as Linux, cope.)</h4>
 
-<br>
 
-If you are looking for a Steam Deck guide, check [this guide](https://github.com/maxastyler/S.T.A.L.K.E.R.-Gamma-Steam-Deck-Install-Guide/) out.  
+
+*If you are looking for a Steam Deck guide, check [this guide](https://github.com/maxastyler/S.T.A.L.K.E.R.-Gamma-Steam-Deck-Install-Guide/) out.*
 
 <h4>DISCLAIMER:</h4>
-This guide is more of a compilation of info that I have gathered together from others in the GAMMA and Linux community that I have simply put together along with a few of my own findings. This guide may not work *for you*, everybody has a different set-up, there may also be things I have forgotten to mention here, my methodology may seem strange to experienced users, and there are liekly typos. That being said I am fairly confident this will work for most people.  
+
+This guide is more of a compilation of info that I have gathered together from others in the GAMMA and Linux community that I have simply put together along with a few of my own findings. This guide may not work *for you,* everybody has a different set-up, there may also be things I have forgotten to mention here, my methodology may seem strange to experienced users, and there are liekly typos. That being said I am fairly confident this will work for most people.  
 
 I don't use Discord anymore, if you need help and you can't get it anywhere else, make an issue.  
 I will _still be merging pull requests_, but since I'm not using Discord, and it is a prerequesite to install GAMMA, I won't be updating the guide with my own findings. If you are unhappy about this, please fork it and do it yourself.
+
+<br>
 
 <ins>***Avoid asking GAMMA support for help with Linux,***</ins> they do not currently support Linux, and can only do so much to help anyway.
 If you have any info to add to the guide; make a _pull request_.
@@ -29,7 +30,11 @@ Depending on how you choose to copy the files over, you may leave some behind in
 - A shared folder in your VM between your Linux host and Windows 10 guest would be optimal for this, if supported by your choice of VM.
 - Otherwise, consider using an external storage drive, a USB drive, or similar physical methods for high speed transferring. You could upload the compressed file to a service such as Mega and re-download it if not possible, but it may not be viable depending on your internet upload/download speed or data caps.
 
+<br>
+
 <h4>Okay, you have the GAMMA files installed, copied over, and ready to go, now what?</h4>
+
+<br>
 
 You have two good options, running the game through Lutris with Wine, or through Steam with Proton.  
 I will be covering the Lutris/Wine route, because that is what has worked *for me* and a few others.  
@@ -39,9 +44,9 @@ I will be assuming that you have used Lutris/Wine before and know the basics of 
 Add ModOrganizer.exe to Lutris, and then configure as follows:  
 
 Try using the Proton Wine version. It should offer you higher FPS (almost native) and smoother mouse movement compared to other runners.
-If Lutris Proton is your choice, consider setting your GAMMA Wineconfig's version to Windows 10. It may help with FPS even more.
+If Lutris Proton is your choice, consider setting your GAMMA Wineconfig's version to Windows 10. It should help with FPS even more.
 
-However, the built in Wine versions that come with Lutris may not work *for you*, if not, experiment (Possibly try the latest Wine development branch next.)
+However, the built in Wine versions that come with Lutris may not work *for you*, if not, experiment (Possibly try the latest Wine development branch.)
 
 Make sure DXVK and VKD3D are enabled.
 - Esync *may* cause issues, disable it if unsure.
@@ -73,9 +78,12 @@ You can close the settings window now, next you need to tell MO2 where the game 
 In the large drop down menu next to the Play button, click "<Edit...>"
 Select Anomaly Launcher in the list, for the Binary path, you want to point it to AnomalyLauncher.exe, it will be in the root folder of the game (Anomaly), it will probably take you to the right place by default.
 For the Start in path, point it at the folder which AnomalyLauncher.exe is in, you can copy the path you set from above and remove "AnomalyLauncher.exe" from it.
-- Eg. \Games\Anomaly\Anomaly Vanilla\AnomalyLauncher.exe  -->  \Games\Anomaly\Anomaly Vanilla\
-- Mod Organizer 2 will automatically turn a forward slash into a backslash, so you can copy the path directly from your file browser.
+- Eg. Z:\home\yourusername\Games\GAMMA\Anomaly Vanilla\AnomalyLauncher.exe  -->  Z:\home\yourusername\Games\GAMMA\Anomaly Vanilla\
+- Mod Organizer 2 will automatically turn a forward slash into a backslash, so you can copy the path of your .exe file directly from your file browser. However, you will have to add Z: in front of / before clicking Apply/OK.
+
 If you want to configure the other executables, you can do so, they are contained within the bin folder at the root of the game, however it isn't necessary.
+
+<br>
 
 At this point, you should be able to run AnomalyLauncher through MO2, launch the game, and the game should at least run, although with a few issues:
 
@@ -104,15 +112,13 @@ It's compatible with existing ReShade presets, and runs natively on Linux.
 - If you want to mess around with the shader menu in game, make a save first. It does not block mouse input from the game, and you might end up throwing a grenade and causing a faction war. Also, for this reason it would not be recommended for a permadeath run.
 
 iii.
-The FPS limiter present in the graphics settings may lead to choppiness and sharp screen tearing. Consider using VSync without the FPS limiter instead. (This was tested with Nvidia's proprietary Linux drivers and may not apply to you.)
+The FPS limiter present in the graphics settings may lead to choppiness and sharp screen tearing. Consider using VSync without the FPS limiter instead. (This was tested with Nvidia's proprietary Linux drivers on plain Arch Linux and may not at all apply to you.)
 
 
 <h4>By now, you should have a fully playable (though likely imperfect) S.T.A.L.K.E.R. - G.A.M.M.A. experience on Linux.</h4>
 
 
 <h3>Thanks to:</h3>
-
-[DravenusRex](https://github.com/DravenusRex/) - Writing the original guide.
 
 no.#3094 (LafreSita) - Groundwork for the wineprefix.  
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # stalker-gamma-linux-guide
-<h3>Unofficially forked from [this git](https://github.com/DravenusRex/stalker-gamma-linux-guide) by [DravenusRex](https://github.com/DravenusRex/)</h3>
+<h3>Unofficially forked from [this git](https://github.com/DravenusRex/stalker-gamma-linux-guide) by [DravenusRex](https://github.com/DravenusRex/) in case of prolonged inactivity.</h3>
 <h4>Updated by me. If you would like to propose a change but you're too lazy to use github, send me an email (Discord dms suck for this) at trash-hell@sren.solutions</h4>
 
 <h3>A guide to getting S.T.A.L.K.E.R. - G.A.M.M.A. running on GNU/Linux.</h3>  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # stalker-gamma-linux-guide
 
-<h3>A guide to getting S.T.A.L.K.E.R. - G.A.M.M.A. running on GNU/Linux.</h3>  
+<h4>Temporary fork of the original guide by DravenusRex made from uncertainty.</h4>
+
+If you have something major to add, you could either make a merge request, or in the case of prolonged inactivity, fork it. If it's something minor or a question, send me an email at ' trash-hell@sren.solutions ' and I'll find a way to put it and the answer/solution in here somehow. Please try your best at clarity, and include your Discord tag if you prefer communicating that way. 
+
+Will be push requested into main when relevant.
+
+<h1>A guide to getting S.T.A.L.K.E.R. - G.A.M.M.A. running on GNU/Linux.</h1>  
 <h4>(Henceforth referred to as Linux, cope.)</h4>
 
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ I will be covering the Lutris/Wine route, because that is what has worked *for m
 
 I will be assuming that you have used Lutris/Wine before and know the basics of configuration.  
 Add ModOrganizer.exe to Lutris, and then configure as follows:  
+
 Try using the Proton Wine version. It should offer you higher FPS (almost native) and smoother mouse movement compared to other runners.
 If Lutris Proton is your choice, consider setting your GAMMA Wineconfig's version to Windows 10. It may help with FPS even more.
+
 However, the built in Wine versions that come with Lutris may not work *for you*, if not, experiment (Possibly try the latest Wine development branch next.)
-Make sure DXVK and VKD3D are enabled.  
-Esync *may* cause issues, disable it if unsure.
+
+Make sure DXVK and VKD3D are enabled.
+- Esync *may* cause issues, disable it if unsure.
+
 For the wineprefix, enable the following DLLs:  
 - cmd
 - d3dcompiler_47
@@ -91,19 +95,23 @@ Close GAMMA and MO2, navigate to the Anomaly folder, open the bin folder, and in
 - ReShade.ini
 
 iia.
-If you cannot go without fancy shaders, consider using [GShade](https://github.com/HereInPlainSight/gshade_installer) instead. It's compatible with existing ReShade presets, and runs natively on Linux. Install to custom game, say yes to dxgi, and point the executable selection to the single specific /bin/ .exe you wish to use it with (Eg. AnomalyDX10.exe OR AnomalyDX10AVX.exe)
-- Move your G.A.M.M.A.Reshade.ini from the /bin/ folder into the newly created /bin/gshade-presets/Custom/ folder and navigate to it in GShade. It might need a moment to compile after being selected.
-- Should work out of the box, but will lag to death on your first load using it as it has to compile ~230 shaders.
+If you cannot go without fancy shaders, consider using [GShade](https://github.com/HereInPlainSight/gshade_installer) instead. 
+
+It's compatible with existing ReShade presets, and runs natively on Linux. 
+- Do install to custom game, say yes to dxgi, and point the executable selection to the single specific /bin/ .exe you wish to use it with (Eg. AnomalyDX10.exe OR AnomalyDX10AVX.exe)
+- Move your G.A.M.M.A.Reshade.ini from the /bin/ folder into the newly created /bin/gshade-presets/Custom/ folder and navigate to it in GShade while loaded into GAMMA. It might need a moment to compile after being selected.
+- Should work out of the box, but it will lag GAMMA hard on your first save load as it has to compile ~230 shaders.
 - If you want to mess around with the shader menu in game, make a save first. It does not block mouse input from the game, and you might end up throwing a grenade and causing a faction war. Also, for this reason it would not be recommended for a permadeath run.
 
 iii.
-The FPS limiter present in the graphics settings may lead to choppiness and sharp screen tearing. Consider using VSync without the FPS limiter instead. (This was tested with Nvidia's proprietary Linux drivers and may not at all apply to you.)
+The FPS limiter present in the graphics settings may lead to choppiness and sharp screen tearing. Consider using VSync without the FPS limiter instead. (This was tested with Nvidia's proprietary Linux drivers and may not apply to you.)
 
 
-By now, you should have a fully playable (though likely imperfect) S.T.A.L.K.E.R. - G.A.M.M.A. experience on Linux.
+<h4>By now, you should have a fully playable (though likely imperfect) S.T.A.L.K.E.R. - G.A.M.M.A. experience on Linux.</h4>
 
 
-Thanks to:  
+<h3>Thanks to:</h3>
+
 [DravenusRex](https://github.com/DravenusRex/) - Writing the original guide.
 
 no.#3094 (LafreSita) - Groundwork for the wineprefix.  

--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
 # stalker-gamma-linux-guide
+<h3>Unofficially forked from [this git](https://github.com/DravenusRex/stalker-gamma-linux-guide) by [DravenusRex](https://github.com/DravenusRex/)</h3>
+<h4>Updated by me. If you would like to propose a change but you're too lazy to use github, send me an email (Discord dms suck for this) at trash-hell@sren.solutions</h4>
+
 <h3>A guide to getting S.T.A.L.K.E.R. - G.A.M.M.A. running on GNU/Linux.</h3>  
 <h4>(Henceforth referred to as Linux, cope.)</h4>
+
 <br>
 
 If you are looking for a Steam Deck guide, check [this guide](https://github.com/maxastyler/S.T.A.L.K.E.R.-Gamma-Steam-Deck-Install-Guide/) out.  
 
-DISCLAIMER:
+<h4>DISCLAIMER:</h4>
 This guide is more of a compilation of info that I have gathered together from others in the GAMMA and Linux community that I have simply put together along with a few of my own findings. This guide may not work *for you*, everybody has a different set-up, there may also be things I have forgotten to mention here, my methodology may seem strange to experienced users, and there are liekly typos. That being said I am fairly confident this will work for most people.  
 
 I don't use Discord anymore, if you need help and you can't get it anywhere else, make an issue.  
 I will _still be merging pull requests_, but since I'm not using Discord, and it is a prerequesite to install GAMMA, I won't be updating the guide with my own findings. If you are unhappy about this, please fork it and do it yourself.
 
-~~You can message me on Discord, "Dravenus Rex#5373",~~ please avoid asking GAMMA support for help, they do not currently support Linux, and can only do so much to help anyway.  
-If you have any info to add to the guide; ~~message me on Discord or~~ make a _pull request_.
+<ins>***Avoid asking GAMMA support for help with Linux,***</ins> they do not currently support Linux, and can only do so much to help anyway.
+If you have any info to add to the guide; make a _pull request_.
 
 As of November 29, 2022, the GAMMA installer uses powershell;  
 As far as I know, <ins>there is not a way to run the installer on Linux.</ins>  
 A few people have tried it with powershell for Linux, it has not worked so far.  
 Grok has plans to rebuild the installer without powershell eventually.  
-I recommend you boot up Windows (VM or otherwise) and install GAMMA there following the standard installation instructions, <ins>***CONFIRM IT WORKS***</ins>, including that the proper number of mods are enabled and that the game runs, and then copy the files over;  
-Depending on how you choose to copy the files over, you may leave some behind in the process due to folder/file name lengths.  
-An easy way to avoid this is by compressing before transferring, and then extracting in Linux.
 
-Okay, you have the GAMMA files installed, copied over, and ready to go, now what?
+I recommend you boot up Windows (VM or otherwise), with 130GB (or 140GB to be safe) of free storage, and install GAMMA there following the standard installation instructions, <ins>***CONFIRM IT WORKS***</ins>, including that the proper number of mods are enabled and that the game launches to the main menu, and then copy the files over.
+Depending on how you choose to copy the files over, you may leave some behind in the process due to folder/file name lengths.  
+- An easy way to avoid this is by compressing before transferring, and then extracting in Linux. A .7z with a compression level of 5 leaves this with a bit over 30GB to transfer.
+- A shared folder in your VM between your Linux host and Windows 10 guest would be optimal for this, if supported by your choice of VM.
+- Otherwise, consider using an external storage drive, a USB drive, or similar physical methods for high speed transferring. You could upload the compressed file to a service such as Mega and re-download it if not possible, but it may not be viable depending on your internet upload/download speed or data caps.
+
+<h4>Okay, you have the GAMMA files installed, copied over, and ready to go, now what?</h4>
 
 You have two good options, running the game through Lutris with Wine, or through Steam with Proton.  
 I will be covering the Lutris/Wine route, because that is what has worked *for me* and a few others.  
@@ -30,10 +37,11 @@ I will be covering the Lutris/Wine route, because that is what has worked *for m
 
 I will be assuming that you have used Lutris/Wine before and know the basics of configuration.  
 Add ModOrganizer.exe to Lutris, and then configure as follows:  
-The built in Wine versions that come with Lutris did not work *for me*. They may or may not *for you*, if not, experiment;  
-Try the latest Wine development branch next. *For me*, Wine 7.19 worked fine.  
+Try using the Proton Wine version. It should offer you higher FPS (almost native) and smoother mouse movement compared to other runners.
+If Lutris Proton is your choice, consider setting your GAMMA Wineconfig's version to Windows 10. It may help with FPS even more.
+However, the built in Wine versions that come with Lutris may not work *for you*, if not, experiment (Possibly try the latest Wine development branch next.)
 Make sure DXVK and VKD3D are enabled.  
-Esync caused issues *for me* so I disabled it.  
+Esync *may* cause issues, disable it if unsure.
 For the wineprefix, enable the following DLLs:  
 - cmd
 - d3dcompiler_47
@@ -61,6 +69,8 @@ You can close the settings window now, next you need to tell MO2 where the game 
 In the large drop down menu next to the Play button, click "<Edit...>"
 Select Anomaly Launcher in the list, for the Binary path, you want to point it to AnomalyLauncher.exe, it will be in the root folder of the game (Anomaly), it will probably take you to the right place by default.
 For the Start in path, point it at the folder which AnomalyLauncher.exe is in, you can copy the path you set from above and remove "AnomalyLauncher.exe" from it.
+- Eg. \Games\Anomaly\Anomaly Vanilla\AnomalyLauncher.exe  -->  \Games\Anomaly\Anomaly Vanilla\
+- Mod Organizer 2 will automatically turn a forward slash into a backslash, so you can copy the path directly from your file browser.
 If you want to configure the other executables, you can do so, they are contained within the bin folder at the root of the game, however it isn't necessary.
 
 At this point, you should be able to run AnomalyLauncher through MO2, launch the game, and the game should at least run, although with a few issues:
@@ -77,24 +87,29 @@ Close GAMMA and MO2, navigate to the Anomaly folder, open the bin folder, and in
 - reshade-shaders
 - d3d9.dll
 - dxgi.dll
-- G.A.M.M.A.Reshade.ini
+- G.A.M.M.A.Reshade.ini    (If following the next step to use shaders on Linux, do not delete this file.)
 - ReShade.ini
 
-iia.  
-If you remove Reshade it is recommended that you disable the mods that use it:
-* Screen Space Shaders - Ascii1457
-* Shaders Cumulative Pack for GAMMA
-* Right click Beef’s NVG addon, click “reinstall mod” and tick the following options:
-  * Beef’s NVG
-  * Beef’s NVG - Patch ES
-* Delete anomaly/appdata/shaders_cache folder
+iia.
+If you cannot go without fancy shaders, consider using [GShade](https://github.com/HereInPlainSight/gshade_installer) instead. It's compatible with existing ReShade presets, and runs natively on Linux. Install to custom game, say yes to dxgi, and point the executable selection to the single specific /bin/ .exe you wish to use it with (Eg. AnomalyDX10.exe OR AnomalyDX10AVX.exe)
+- Move your G.A.M.M.A.Reshade.ini from the /bin/ folder into the newly created /bin/gshade-presets/Custom/ folder and navigate to it in GShade. It might need a moment to compile after being selected.
+- Should work out of the box, but will lag to death on your first load using it as it has to compile ~230 shaders.
+- If you want to mess around with the shader menu in game, make a save first. It does not block mouse input from the game, and you might end up throwing a grenade and causing a faction war. Also, for this reason it would not be recommended for a permadeath run.
+
+iii.
+The FPS limiter present in the graphics settings may lead to choppiness and sharp screen tearing. Consider using VSync without the FPS limiter instead. (This was tested with Nvidia's proprietary Linux drivers and may not at all apply to you.)
+
 
 By now, you should have a fully playable (though likely imperfect) S.T.A.L.K.E.R. - G.A.M.M.A. experience on Linux.
 
 
-Thanks:  
+Thanks to:  
+[DravenusRex](https://github.com/DravenusRex/) - Writing the original guide.
+
 no.#3094 (LafreSita) - Groundwork for the wineprefix.  
+
 yeyande#9033 (yeyande) - Unintentionally helping me find the cause of the key repeat stutter.  
+
 maxastyler and his [Steam Deck Guide](https://github.com/maxastyler/S.T.A.L.K.E.R.-Gamma-Steam-Deck-Install-Guide/)
 
 


### PR DESCRIPTION
I recently followed your guide, but had to make some adjustments to make it work on my desktop Arch Linux system as of (2022/01/21).

Please consider my proposed changes:

1. The Windows 10 (tested on Home edition) virtual machine needed for the installation process (for powershell) should have its disk size specified.
I was able to install gamma, however it ran out of space on the drive about 80% into the process
I threw it in the calculator, and... you would need at least 130GB now, with a possibility of 140GB depending on randomness.

2. Do not disable/reinstall the shader and gas mask mods in the ReShade process, as it will result in a shader failed to generate crash on game save load. Not uninstalling the mods does not appear to negatively affect the experience without ReShade in any way.

3. In Lutris, set your Gamma install's Wine Version to lutris-GE-Proton-7-33-x86_64, or whichever the newest version of the Proton one is. This will enable the game to run as smoothly as it possibly can according to system specs, I get 20-30 more FPS than on Windows with this version.

4. In Lutris, open "Wine Configuration" with Gamma selected by hitting the arrow next to the Wine glass at the bottom, and set "Windows Version" to 10 rather than 7, Apply/OK. Might be unnecessary, but this could tie in with the previous change, and doesn't seem to negatively impact anything.

5. Ingame, the FPS Limiter will lead to choppiness on Linux, but VSync in its place will not. (Possibly not the case on all systems, but it might be the case for Nvidia proprietary driver users? Added a disclaimer for that.)

6. Added suggestions on compressed install transfer.

7. GShade as a ReShade-compatible native Linux replacement suggestion, tested to not have the ReShade input bug and to work with the included GAMMA reshade config. With some extra tips.

8. Some minor readability changes that I thought might work.

I hope it'll help!
